### PR TITLE
Tiny bug fix

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -66,7 +66,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     config.userContentController = userController;
     
     config.allowsInlineMediaPlayback = YES;
-    config.mediaPlaybackRequiresUserAction = WKAudiovisualMediaTypeNone;
+    config.mediaPlaybackRequiresUserAction = NO;
+    config.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
     config.requiresUserActionForMediaPlayback = NO;
     
     _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration:config];


### PR DESCRIPTION
@ptelad Stumbled upon this misconfiguration, please take a look and merge if it looks good. Thanks!


Use correct WKWebViewConfiguration properties/values for disabling requiring user action for media playback.

See API:
https://developer.apple.com/documentation/webkit/wkwebviewconfiguration